### PR TITLE
feat: add autotagging

### DIFF
--- a/example/github/github.yaml
+++ b/example/github/github.yaml
@@ -1,10 +1,13 @@
+autotags:
+  - regex: ".*github.*"
+    tags: ["github"]
 links: 
   - url: https://github.com/kubernetes/kubernetes
     description: "kubernetes main github repo"
-    tags: ["k8s","github"]
+    tags: ["k8s"]
   - url: https://github.com/goharbor/harbor
     description: "kubernetes main github repo"
-    tags: ["oci", "k8s","github"]
+    tags: ["oci", "k8s"]
   - url: https://github.com/sigstore/cosign
     description: "CNCF graduated OCI registry"
     tags: ["oci"]

--- a/links.yaml
+++ b/links.yaml
@@ -1,0 +1,26 @@
+groups:
+    - name: default
+      description: ""
+      tags:
+        - default
+links:
+    - url: https://yx.mLwlNVZ0wN.org
+      displayname: ""
+      description: ""
+      tags:
+        - default
+    - url: https://hs.nuq3H3LNcCh.co
+      displayname: ""
+      description: ""
+      tags:
+        - default
+    - url: https://47YVXqM.edu
+      displayname: ""
+      description: ""
+      tags:
+        - default
+    - url: https://github.com/kubernetes/dargon
+      displayname: ""
+      description: ""
+      tags:
+        - default

--- a/pkg/backends/inmemory/add.go
+++ b/pkg/backends/inmemory/add.go
@@ -55,6 +55,7 @@ func (i *InMemoryBackend) Add(r *proto.CartographerAddRequest) (*proto.Cartograp
 		if g := i.Groups.GetGroup(group.Name); g == nil {
 			log.Printf("Adding Groups %s", group.Name)
 			i.Groups[group.Name] = data.NewGroup(group.Name)
+			resp.Response.Msg = append(resp.Response.Msg, fmt.Sprintf("Adding Group %s", group.Name))
 		}
 
 		// Add all tags to group

--- a/pkg/backends/inmemory/add.go
+++ b/pkg/backends/inmemory/add.go
@@ -61,7 +61,7 @@ func (i *InMemoryBackend) Add(r *proto.CartographerAddRequest) (*proto.Cartograp
 		// Add all tags to group
 		for _, tag := range r.Request.Tags {
 			log.Printf("Adding Tags to group %s %s", group.Name, r.Request.Tags)
-			i.Groups[group.Name].GroupTags = append(i.Groups[group.Name].GroupTags, i.Tags[tag.Name])
+			i.Groups[group.Name].AddTag(i.Tags[tag.Name])
 		}
 	}
 

--- a/pkg/backends/inmemory/add.go
+++ b/pkg/backends/inmemory/add.go
@@ -9,6 +9,9 @@ import (
 )
 
 // TODO I hate this function
+// This should be refactored to be more efficient and less complex
+// We should accept multiple links in a single request, and the tags sent along with the link should be honored
+// We should not allow sending of tags outside of them being added to the link
 func (i *InMemoryBackend) Add(r *proto.CartographerAddRequest) (*proto.CartographerAddResponse, error) {
 
 	resp := proto.CartographerAddResponse{
@@ -23,6 +26,7 @@ func (i *InMemoryBackend) Add(r *proto.CartographerAddRequest) (*proto.Cartograp
 	// Process Links
 	for _, link := range r.Request.Links {
 		if _, exists := i.Links[link.Url]; !exists {
+
 			l, err := data.NewFromProtoLink(link)
 			if err == nil {
 				log.Printf("adding %s", l.Link.String())
@@ -44,7 +48,7 @@ func (i *InMemoryBackend) Add(r *proto.CartographerAddRequest) (*proto.Cartograp
 
 		// Add tag to links
 		for _, link := range newLinks {
-			link.Tags = append(link.Tags, i.Tags[tag.Name])
+			link.AddTag(i.Tags[tag.Name])
 		}
 	}
 

--- a/pkg/backends/inmemory/add_test.go
+++ b/pkg/backends/inmemory/add_test.go
@@ -14,19 +14,23 @@ func TestInMemoryBackend_Add(t *testing.T) {
 	req := &proto.CartographerAddRequest{
 		Request: &proto.CartographerRequest{
 			Links: []*proto.Link{
-				{Url: "http://example.com"},
+				{
+					Url:  "http://example.com",
+					Tags: []string{"example"},
+				},
 			},
 			Tags: []*proto.Tag{
 				{Name: "example"},
 			},
 			Groups: []*proto.Group{
-				{Name: "exampleGroup"},
+				{Name: "exampleGroup", Tags: []string{"example"}},
 			},
 		},
 	}
 
 	resp, err := backend.Add(req)
 	assert.NoError(t, err)
+
 	assert.NotNil(t, resp)
 	assert.Contains(t, resp.Response.Msg, "Adding http://example.com")
 

--- a/pkg/backends/inmemory/backup.go
+++ b/pkg/backends/inmemory/backup.go
@@ -33,6 +33,7 @@ func (i *InMemoryBackend) Export() *config.CartographerConfig {
 	for _, group := range i.Groups {
 		g := proto.Group{
 			Name: group.Name,
+			Tags: make([]string, 0),
 		}
 
 		for _, tag := range group.GroupTags {

--- a/pkg/backends/inmemory/get.go
+++ b/pkg/backends/inmemory/get.go
@@ -114,6 +114,7 @@ func (i *InMemoryBackend) ProcessDataRequest(r *proto.CartographerRequest) (*pro
 					lm[link.Link.String()] = link.GetProtoLink()
 					//responseLinks = append(responseLinks, link.GetProtoLink())
 				}
+
 				for _, link := range lm {
 					responseLinks = append(responseLinks, link)
 				}
@@ -125,14 +126,15 @@ func (i *InMemoryBackend) ProcessDataRequest(r *proto.CartographerRequest) (*pro
 				resp.Groups = append(resp.Groups, g.Name)
 				for _, tag := range g.GroupTags {
 					resp.Tags = append(resp.Tags, tag.Name)
+
 					// TODO refine this
 					// this is duplicating links that are in multiple tags
 					lm := make(map[string]*proto.Link, 0)
 					if t, exists := i.Tags[tag.Name]; exists {
-						resp.Tags = append(resp.Tags, t.Name)
 						for _, link := range t.Links {
 							lm[link.Link.String()] = link.GetProtoLink()
 						}
+
 						for _, link := range lm {
 							responseLinks = append(responseLinks, link)
 						}

--- a/pkg/backends/inmemory/initalize.go
+++ b/pkg/backends/inmemory/initalize.go
@@ -44,7 +44,7 @@ func (i *InMemoryBackend) Initialize(c *config.CartographerConfig) error {
 		d := data.NewGroup(group.Name)
 		for _, tagName := range group.Tags {
 			if tag, exists := i.Tags[tagName]; exists {
-				d.GroupTags = append(d.GroupTags, tag)
+				d.AddTag(tag)
 				d.Links = append(d.Links, tag.Links...)
 			}
 		}

--- a/pkg/backends/inmemory/initalize.go
+++ b/pkg/backends/inmemory/initalize.go
@@ -3,21 +3,25 @@ package inmemory
 import (
 	"log"
 
+	"github.com/rjbrown57/cartographer/pkg/types/auto"
 	"github.com/rjbrown57/cartographer/pkg/types/config"
 	"github.com/rjbrown57/cartographer/pkg/types/data"
 )
 
 // Needs to refactored to use Group/Tag/Link methods
-func (i *InMemoryBackend) Initialize(config *config.CartographerConfig) error {
+func (i *InMemoryBackend) Initialize(c *config.CartographerConfig) error {
 
 	// Create all Groups
 	// Create all Tags
 	// Create all Links
 
-	log.Printf("Initializing inmemory backend with %d links", len(config.Links))
+	log.Printf("Initializing inmemory backend with %d links", len(c.Links))
 
 	// Process all links
-	for _, link := range config.Links {
+	for _, link := range c.Links {
+
+		auto.ProcessAutoTags(link, c.AutoTags)
+
 		d, err := data.NewFromProtoLink(link)
 
 		if err != nil {
@@ -36,7 +40,7 @@ func (i *InMemoryBackend) Initialize(config *config.CartographerConfig) error {
 	}
 
 	// Process Groups
-	for _, group := range config.Groups {
+	for _, group := range c.Groups {
 		d := data.NewGroup(group.Name)
 		for _, tagName := range group.Tags {
 			if tag, exists := i.Tags[tagName]; exists {

--- a/pkg/proto/cartographer/v1/utils.go
+++ b/pkg/proto/cartographer/v1/utils.go
@@ -25,23 +25,23 @@ func NewProtoTag(tagName, description string) *Tag {
 func NewCartographerRequest(links, tags, groups []string) *CartographerRequest {
 	newlinks := make([]*Link, 0)
 
-	deDupMap := make(map[string]bool)
+	deDupMap := make(map[string]struct{})
 
 	for _, link := range links {
 		if _, ok := deDupMap[link]; !ok {
 			newlinks = append(newlinks, NewProtoLink(link, "", "", tags))
 		}
-		deDupMap[link] = true
+		deDupMap[link] = struct{}{}
 	}
 
-	deDupMap = make(map[string]bool)
+	deDupMap = make(map[string]struct{})
 
 	newTags := make([]*Tag, 0)
 	for _, tag := range tags {
 		if _, ok := deDupMap[tag]; !ok {
 			newTags = append(newTags, NewProtoTag(tag, ""))
 		}
-		deDupMap[tag] = true
+		deDupMap[tag] = struct{}{}
 	}
 
 	newGroups := make([]*Group, 0)

--- a/pkg/types/auto/doc.go
+++ b/pkg/types/auto/doc.go
@@ -1,0 +1,1 @@
+package auto

--- a/pkg/types/auto/tag.go
+++ b/pkg/types/auto/tag.go
@@ -16,7 +16,7 @@ type AutoTag struct {
 // ProcessAutoTags will process the auto tags for a link
 func ProcessAutoTags(link *proto.Link, at []*AutoTag) {
 
-	autoTags := make(map[string]bool)
+	autoTags := make(map[string]struct{})
 
 	// Add initial tags so we can dedup
 	for _, tag := range link.Tags {
@@ -27,7 +27,7 @@ func ProcessAutoTags(link *proto.Link, at []*AutoTag) {
 		// if the tag matches, add to the tagMap
 		if autoTag.Regex.MatchString(link.Url) {
 			for _, tag := range autoTag.Tags {
-				autoTags[tag] = true
+				autoTags[tag] = struct{}{}
 			}
 		}
 	}

--- a/pkg/types/auto/tag.go
+++ b/pkg/types/auto/tag.go
@@ -1,0 +1,47 @@
+package auto
+
+import (
+	"log"
+	"regexp"
+
+	proto "github.com/rjbrown57/cartographer/pkg/proto/cartographer/v1"
+)
+
+type AutoTag struct {
+	Regex       *regexp.Regexp `yaml:"-"`
+	RegexString string         `yaml:"regex,omitempty"`
+	Tags        []string       `yaml:"tags,omitempty"`
+}
+
+// ProcessAutoTags will process the auto tags for a link
+func ProcessAutoTags(link *proto.Link, at []*AutoTag) {
+
+	autoTags := make(map[string]bool)
+
+	// Add initial tags so we can dedup
+	for _, tag := range link.Tags {
+		autoTags[tag] = struct{}{}
+	}
+
+	for _, autoTag := range at {
+		// if the tag matches, add to the tagMap
+		if autoTag.Regex.MatchString(link.Url) {
+			for _, tag := range autoTag.Tags {
+				autoTags[tag] = true
+			}
+		}
+	}
+
+	link.Tags = link.Tags[:0] // Clear the existing tags to avoid duplication
+
+	for tag := range autoTags {
+		link.Tags = append(link.Tags, tag)
+	}
+
+}
+
+// Configure will compile the regex for the auto tag
+func (a *AutoTag) Configure() {
+	log.Printf("Configuring auto tag `%s` - %s", a.RegexString, a.Tags)
+	a.Regex = regexp.MustCompile(a.RegexString)
+}

--- a/pkg/types/auto/tag_test.go
+++ b/pkg/types/auto/tag_test.go
@@ -1,0 +1,137 @@
+package auto
+
+import (
+	"regexp"
+	"testing"
+
+	proto "github.com/rjbrown57/cartographer/pkg/proto/cartographer/v1"
+)
+
+func TestProcessAutoTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		link     *proto.Link
+		autoTags []*AutoTag
+		expected []string
+	}{
+		{
+			name: "Single match",
+			link: &proto.Link{Url: "http://example.com"},
+			autoTags: []*AutoTag{
+				{
+					Regex:       regexp.MustCompile("example"),
+					RegexString: "example",
+					Tags:        []string{"example-tag"},
+				},
+			},
+			expected: []string{"example-tag"},
+		},
+		{
+			name: "dedup validation",
+			link: &proto.Link{Url: "http://example.com", Tags: []string{"example-tag"}},
+			autoTags: []*AutoTag{
+				{
+					Regex:       regexp.MustCompile("example"),
+					RegexString: "example",
+					Tags:        []string{"example-tag"},
+				},
+			},
+			expected: []string{"example-tag"},
+		},
+		{
+			name: "Multiple matches",
+			link: &proto.Link{Url: "http://example.com"},
+			autoTags: []*AutoTag{
+				{
+					Regex:       regexp.MustCompile("example"),
+					RegexString: "example",
+					Tags:        []string{"example-tag"},
+				},
+				{
+					Regex:       regexp.MustCompile("com"),
+					RegexString: "com",
+					Tags:        []string{"com-tag"},
+				},
+			},
+			expected: []string{"example-tag", "com-tag"},
+		},
+		{
+			name: "No match",
+			link: &proto.Link{Url: "http://example.com"},
+			autoTags: []*AutoTag{
+				{
+					Regex:       regexp.MustCompile("nomatch"),
+					RegexString: "nomatch",
+					Tags:        []string{"nomatch-tag"},
+				},
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ProcessAutoTags(tt.link, tt.autoTags)
+			if len(tt.link.Tags) != len(tt.expected) {
+				t.Errorf("expected %v tags, got %v", len(tt.expected), len(tt.link.Tags))
+			}
+			for _, tag := range tt.expected {
+				found := false
+				for _, linkTag := range tt.link.Tags {
+					if tag == linkTag {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected tag %v not found in link tags %v", tag, tt.link.Tags)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigure(t *testing.T) {
+	tests := []struct {
+		name       string
+		autoTag    *AutoTag
+		shouldFail bool
+	}{
+		{
+			name: "Valid regex",
+			autoTag: &AutoTag{
+				RegexString: "example",
+				Tags:        []string{"example-tag"},
+			},
+			shouldFail: false,
+		},
+		{
+			name: "Invalid regex",
+			autoTag: &AutoTag{
+				RegexString: "[invalid",
+				Tags:        []string{"invalid-tag"},
+			},
+			shouldFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if !tt.shouldFail {
+						t.Errorf("unexpected panic: %v", r)
+					}
+				} else {
+					if tt.shouldFail {
+						t.Errorf("expected panic but did not occur")
+					}
+				}
+			}()
+			tt.autoTag.Configure()
+			if !tt.shouldFail && tt.autoTag.Regex == nil {
+				t.Errorf("expected regex to be compiled, but it was nil")
+			}
+		})
+	}
+}

--- a/pkg/types/config/config.go
+++ b/pkg/types/config/config.go
@@ -9,6 +9,7 @@ import (
 
 	proto "github.com/rjbrown57/cartographer/pkg/proto/cartographer/v1"
 	"github.com/rjbrown57/cartographer/pkg/types/auto"
+	"github.com/rjbrown57/cartographer/pkg/types/client"
 	"github.com/rjbrown57/cartographer/pkg/utils"
 )
 
@@ -119,4 +120,31 @@ func (c *CartographerConfig) MergeConfig(mc *CartographerConfig) {
 	for _, link := range mc.Links {
 		c.Links = append(c.Links, link)
 	}
+}
+
+func (c *CartographerConfig) AddToBackend(client *client.CartographerClient) ([]*proto.CartographerAddResponse, error) {
+
+	responses := []*proto.CartographerAddResponse{}
+
+	// Add all new links
+	for _, link := range c.Links {
+		r := proto.NewCartographerAddRequest([]string{link.GetUrl()}, link.GetTags(), nil)
+		resp, err := client.Client.Add(client.Ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, resp)
+	}
+
+	// Add all new groups
+	for _, group := range c.Groups {
+		r := proto.NewCartographerAddRequest(nil, group.GetTags(), []string{group.Name})
+		resp, err := client.Client.Add(client.Ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, resp)
+	}
+
+	return responses, nil
 }

--- a/pkg/types/config/config.go
+++ b/pkg/types/config/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	proto "github.com/rjbrown57/cartographer/pkg/proto/cartographer/v1"
+	"github.com/rjbrown57/cartographer/pkg/types/auto"
 	"github.com/rjbrown57/cartographer/pkg/utils"
 )
 
@@ -32,10 +33,11 @@ type WebConfig struct {
 }
 
 type CartographerConfig struct {
-	ApiVersion   string         `yaml:"apiVersion,omitempty"`
-	ServerConfig ServerConfig   `yaml:"cartographer,omitempty"`
-	Groups       []*proto.Group `yaml:"groups,omitempty"`
-	Links        []*proto.Link  `yaml:"links,omitempty"`
+	ApiVersion   string          `yaml:"apiVersion,omitempty"`
+	AutoTags     []*auto.AutoTag `yaml:"autotags,omitempty"`
+	ServerConfig ServerConfig    `yaml:"cartographer,omitempty"`
+	Groups       []*proto.Group  `yaml:"groups,omitempty"`
+	Links        []*proto.Link   `yaml:"links,omitempty"`
 }
 
 func NewCartographerConfig(configPath string) *CartographerConfig {
@@ -60,6 +62,10 @@ func NewCartographerConfig(configPath string) *CartographerConfig {
 	}
 
 	c.SetApi()
+
+	for _, a := range c.AutoTags {
+		a.Configure()
+	}
 
 	return &c
 }
@@ -100,6 +106,10 @@ func (c *CartographerConfig) MergeConfig(mc *CartographerConfig) {
 	if (ServerConfig{}) == c.ServerConfig {
 		c.ServerConfig = mc.ServerConfig
 		mc.SetApi()
+	}
+
+	for _, autoTag := range mc.AutoTags {
+		c.AutoTags = append(c.AutoTags, autoTag)
 	}
 
 	for _, group := range mc.Groups {

--- a/pkg/types/data/group.go
+++ b/pkg/types/data/group.go
@@ -22,3 +22,16 @@ func (lg *Group) GetBytes() []byte {
 	}
 	return nil
 }
+
+func (lg *Group) AddTag(tag *Tag) {
+
+	tm := make(map[string]struct{})
+
+	for _, t := range lg.GroupTags {
+		tm[t.Name] = struct{}{}
+	}
+
+	if _, exists := tm[tag.Name]; !exists {
+		lg.GroupTags = append(lg.GroupTags, tag)
+	}
+}

--- a/pkg/types/data/group_test.go
+++ b/pkg/types/data/group_test.go
@@ -1,0 +1,45 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewGroup(t *testing.T) {
+	group := NewGroup("testGroup")
+	assert.NotNil(t, group)
+	assert.Equal(t, "testGroup", group.Name)
+	assert.Nil(t, group.GroupTags)
+	assert.Nil(t, group.Links)
+}
+
+func TestGroup_GetBytes(t *testing.T) {
+	group := NewGroup("testGroup")
+	bytes := group.GetBytes()
+	assert.NotNil(t, bytes)
+
+	var unmarshalledGroup Group
+	err := yaml.Unmarshal(bytes, &unmarshalledGroup)
+	assert.Nil(t, err)
+	assert.Equal(t, group.Name, unmarshalledGroup.Name)
+}
+
+func TestGroup_AddTag(t *testing.T) {
+	group := NewGroup("testGroup")
+	tag1 := &Tag{Name: "tag1"}
+	tag2 := &Tag{Name: "tag2"}
+
+	group.AddTag(tag1)
+	assert.Equal(t, 1, len(group.GroupTags))
+	assert.Equal(t, "tag1", group.GroupTags[0].Name)
+
+	group.AddTag(tag2)
+	assert.Equal(t, 2, len(group.GroupTags))
+	assert.Equal(t, "tag2", group.GroupTags[1].Name)
+
+	// Adding the same tag again should not increase the length
+	group.AddTag(tag1)
+	assert.Equal(t, 2, len(group.GroupTags))
+}

--- a/pkg/types/data/link.go
+++ b/pkg/types/data/link.go
@@ -67,10 +67,10 @@ func (l *Link) SetDisplayName() {
 
 func (l *Link) AddTag(tag *Tag) {
 
-	tm := make(map[string]bool)
+	tm := make(map[string]struct{})
 
 	for _, t := range l.Tags {
-		tm[t.Name] = true
+		tm[t.Name] = struct{}{}
 	}
 
 	if _, exists := tm[tag.Name]; !exists {

--- a/pkg/types/data/link.go
+++ b/pkg/types/data/link.go
@@ -64,3 +64,16 @@ func (l *Link) SetDisplayName() {
 		l.DisplayName = s
 	}
 }
+
+func (l *Link) AddTag(tag *Tag) {
+
+	tm := make(map[string]bool)
+
+	for _, t := range l.Tags {
+		tm[t.Name] = true
+	}
+
+	if _, exists := tm[tag.Name]; !exists {
+		l.Tags = append(l.Tags, tag)
+	}
+}

--- a/pkg/types/server/backend.go
+++ b/pkg/types/server/backend.go
@@ -4,10 +4,15 @@ import (
 	"context"
 
 	proto "github.com/rjbrown57/cartographer/pkg/proto/cartographer/v1"
+	"github.com/rjbrown57/cartographer/pkg/types/auto"
 	"google.golang.org/grpc"
 )
 
 func (c *CartographerServer) Add(_ context.Context, in *proto.CartographerAddRequest) (*proto.CartographerAddResponse, error) {
+	for _, link := range in.Request.GetLinks() {
+		auto.ProcessAutoTags(link, c.config.AutoTags)
+	}
+
 	return c.Backend.Add(in)
 }
 

--- a/pkg/types/server/server.go
+++ b/pkg/types/server/server.go
@@ -49,6 +49,8 @@ func NewCartographerServer(o *CartographerServerOptions) *CartographerServer {
 		Options:   o,
 		Backend:   inmemory.NewInMemoryBackend(&conf.ServerConfig.BackupConfig),
 		WebServer: ui.NewCartographerUI(&conf.ServerConfig),
+
+		config: conf,
 	}
 
 	err = c.Backend.Initialize(conf)


### PR DESCRIPTION
Add ability to configure automatic tagging of links based on regex and list of tags.

Example:
```
autotags:
  - regex: ".*github.*"
    tags: ["github"]
```

any tag added via config or `client add` that matches this regex will add github tag